### PR TITLE
Vmsyncv2

### DIFF
--- a/cmd/vmsync/cmd.go
+++ b/cmd/vmsync/cmd.go
@@ -11,7 +11,7 @@ import (
 var vcenter, datacenter, cluster, folder, userID, secret string
 
 var csvFile string
-var ignoreState, umwl, keepFile, keepFQDNHostname, deprecated, insecure, allIPs, vcName, ipv6 bool
+var ignoreState, ignoreSubfolders, umwl, keepFile, keepFQDNHostname, deprecated, insecure, allIPs, vcName, ipv6 bool
 var updatePCE, noPrompt bool
 var vc VCenter
 var maxCreate, maxUpdate int
@@ -29,11 +29,12 @@ func init() {
 	VCenterSyncCmd.Flags().BoolVarP(&insecure, "insecure", "i", false, "ignore vcenter ssl certificate validation.")
 	VCenterSyncCmd.Flags().StringVarP(&datacenter, "datacenter", "d", "", "limit sync a specific vcenter catacenter.")
 	VCenterSyncCmd.Flags().StringVarP(&cluster, "cluster", "c", "", "limit sync to a specific vcenter cluster.")
-	VCenterSyncCmd.Flags().StringVarP(&folder, "folder", "f", "", "limit sync to a specific vcenter folder.")
+	VCenterSyncCmd.Flags().StringVarP(&folder, "folder", "f", "", "limit sync to a specific vcenter folder and subfolders.")
 	VCenterSyncCmd.Flags().BoolVarP(&umwl, "umwl", "", false, "create unmanaged workloads for VMs that do not exist in the PCE. future updtaes will only update labels.")
 	VCenterSyncCmd.Flags().BoolVarP(&allIPs, "all-int", "a", false, "enable syncing multiple interfaces")
 	VCenterSyncCmd.Flags().BoolVarP(&ipv6, "ipv6", "", false, "used with all-int to sync ipv6 addresses.")
 	VCenterSyncCmd.Flags().BoolVarP(&ignoreState, "ignore-state", "", false, "sync workloads in states other than \"Powered_on\".")
+	VCenterSyncCmd.Flags().BoolVarP(&ignoreSubfolders, "ignore-subfolders", "", false, "only searches the 'folders' for VMs.  Doesnt look in subfolders. ")
 	VCenterSyncCmd.Flags().BoolVarP(&vcName, "vcentername", "", false, "match on vcenter VM name vs. using VMTools hostname.")
 	VCenterSyncCmd.Flags().BoolVarP(&keepFile, "keep-file", "", false, "keep the csv file used for assigning labels.")
 	VCenterSyncCmd.Flags().BoolVarP(&keepFQDNHostname, "keep-fqdn", "", false, "keep fqdn vs. removing the domain from the hostname.")

--- a/cmd/vmsync/cmd.go
+++ b/cmd/vmsync/cmd.go
@@ -55,7 +55,10 @@ var VCenterSyncCmd = &cobra.Command{
 	Long: `
 Sync VCenter VM tags with PCE workload labels.
 
-The first argument is the location of a csv file that maps VCenter Categories to PCE label keys. The csv skips the first row for headers. The VCenter category should be in the first column and the corredsponding illumio label key in the second.
+A csv file is needed to map VCenter Categories to PCE label keys. The csv skips the first row expecting headers. 
+The VCenter category should be in the first column and the corredsponding illumio label key in the second.  
+
+For all VCenter object (datacenter, cluster, folder) you can enter more than one.  They need to be seperated by commas without spaces.
 	
 Support VCenter version > 7.0.u2`,
 

--- a/cmd/vmsync/vcenter.go
+++ b/cmd/vmsync/vcenter.go
@@ -243,7 +243,7 @@ func (vc *VCenter) getVCenterVMs() int {
 			utils.LogError(fmt.Sprintf("Error Get Vcenter \"%s\" object \"%s\" returned %d entries.  Check for correctness. ", "folder", folder, len(objects)))
 		}
 		tmpObjectIds := objects
-		for {
+		for !ignoreSubfolders {
 			subFolderIds := vc.getObjectID("parent_folders", objects)
 			objects = subFolderIds
 			if len(subFolderIds) == 0 {

--- a/go.sum
+++ b/go.sum
@@ -42,16 +42,6 @@ github.com/aws/aws-sdk-go v1.44.243 h1:f5cNDSVfU/TsH0FXi+DwPjOY4XAv9ehubfw/7yTQQ
 github.com/aws/aws-sdk-go v1.44.243/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/brian1917/illumioapi v1.85.0 h1:f24Qdl4CBGmLATY/w1E4Yw5EC6P+24EawUsk3oaUHes=
 github.com/brian1917/illumioapi v1.85.0/go.mod h1:jREIUsMQeaaL7Mde0nTG2ehSDJjRSU79WFgFXcm0XhQ=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.30 h1:B+ynJ0v/+tD1Xt2/KPqpU5wIaCCjU2+wrmGhIl8QQcs=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.30/go.mod h1:2uy7bernq5Ein6PiTS+9a4VvjYEMKi3vAGybByDZ2c8=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.31 h1:3a8hZDxViOxNKQiTj8AhOro/69RARZlmpVQYUSGzXm4=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.31/go.mod h1:2uy7bernq5Ein6PiTS+9a4VvjYEMKi3vAGybByDZ2c8=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.32 h1:OcMTCIx5zOSPo29HLXGsX+PIP6zgrsU7bxBPugFMFHg=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.32/go.mod h1:2uy7bernq5Ein6PiTS+9a4VvjYEMKi3vAGybByDZ2c8=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.33 h1:/VQMagDvEVJwH/qv1pvKwSFJMMDGj7oLTe0H98xIKgk=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.33/go.mod h1:2uy7bernq5Ein6PiTS+9a4VvjYEMKi3vAGybByDZ2c8=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.34 h1:0iT/eovjvLd53HnWHGlONa/h8huHBlFP0v6/dTyNQVA=
-github.com/brian1917/illumioapi/v2 v2.0.0-beta.34/go.mod h1:2uy7bernq5Ein6PiTS+9a4VvjYEMKi3vAGybByDZ2c8=
 github.com/brian1917/illumioapi/v2 v2.0.0-beta.35 h1:PeCryhh0vpjhnx++dRadIp5gI+FGE+3UKUqG05TJV7M=
 github.com/brian1917/illumioapi/v2 v2.0.0-beta.35/go.mod h1:2uy7bernq5Ein6PiTS+9a4VvjYEMKi3vAGybByDZ2c8=
 github.com/brian1917/ns v1.2.0 h1:8z9dR8WhaqJPTi8Ygyf6VHrYGoP8dbNV8hoD30/k/8c=


### PR DESCRIPTION
Added new logic to stop if no VMs returned from VCenter as well as ability to include more than one filter element in the filter object.  These are separated by commas.  Lastly, added the ability to traverse the folders to pull all subfolders with an option to not do that.