### PR TITLE
fix: rule-export --output-file overwrites instead of appending

### DIFF
--- a/cmd/portusage/cmd.go
+++ b/cmd/portusage/cmd.go
@@ -2,6 +2,7 @@ package portusage
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -200,6 +201,9 @@ func unusedPorts() {
 		}
 
 	}
+
+	// Remove existing file so WriteLineOutput doesn't append to a previous run's output
+	os.Remove(outputFileName)
 
 	// Start the file
 	utils.WriteLineOutput([]string{"hostname", "href", "port", "protocol", "async_query_href", "async_query_status", "flows"}, outputFileName)

--- a/cmd/processexport/cmd.go
+++ b/cmd/processexport/cmd.go
@@ -2,6 +2,7 @@ package processexport
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -129,6 +130,9 @@ func ExportProcesses(pce ia.PCE, outputFileName string) {
 	if outputFileName == "" {
 		outputFileName = fmt.Sprintf("workloader-process-export-%s.csv", time.Now().Format("20060102_150405"))
 	}
+
+	// Remove existing file so WriteLineOutput doesn't append to a previous run's output
+	os.Remove(outputFileName)
 
 	// Setup CSV Data
 	headers := []string{"hostname", "href", "process_path", "service_name", "port", "proto"}

--- a/cmd/ruleexport/cmd.go
+++ b/cmd/ruleexport/cmd.go
@@ -7,6 +7,7 @@ package ruleexport
 
 import (
 	"fmt"
+	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -280,6 +281,8 @@ func (r *RuleExport) ExportToCsv() {
 	if input.OutputFileName == "" {
 		input.OutputFileName = fmt.Sprintf("workloader-rule-export-%s.csv", time.Now().Format("20060102_150405"))
 	}
+	// Remove existing file so WriteLineOutput doesn't append to a previous run's output
+	os.Remove(input.OutputFileName)
 	utils.WriteLineOutput(headerSlice, input.OutputFileName)
 
 	var policyVersionNumberString string


### PR DESCRIPTION
## Summary
- Fixes #129: `rule-export --output-file` now overwrites the file instead of appending to it
- The root cause is `utils.WriteLineOutput()` using `os.O_APPEND` when the file exists. Since the function is called line-by-line, we can't change it to truncate (it would lose data mid-export). Instead, the output file is removed before the first write.
- Applied the same fix to `port-usage` and `process-export` which use the same `WriteLineOutput` pattern and have the same bug.

## Test plan
- [ ] Run `rule-export --output-file test.csv` twice and verify the file contains only one export's worth of data
- [ ] Run `port-usage` and `process-export` with output files to confirm the same fix works

🤖 Generated with [Claude Code](https://claude.com/claude-code)