### PR TITLE
fix: restore unpair CSV output file generation

### DIFF
--- a/cmd/unpair/unpair.go
+++ b/cmd/unpair/unpair.go
@@ -165,8 +165,19 @@ func unpair() {
 		wkldExport.WriteToCsv(hrefFile)
 	}
 
+	// Build label key headers from label dimensions
+	labelKeys := []string{}
+	for _, ld := range pce.LabelDimensionsSlice {
+		labelKeys = append(labelKeys, ld.Key)
+	}
+
 	// Run validation
 	vensToUnpair := []illumioapi.VEN{}
+	csvData := [][]string{}
+	csvHeaders := append([]string{"hostname", "href", "ven_href"}, labelKeys...)
+	csvHeaders = append(csvHeaders, "last_heartbeat", "hours_since_last_heartbeat")
+	csvData = append(csvData, csvHeaders)
+
 	for i, v := range processVENsFile() {
 
 		if val, ok := pce.VENs[v.Href]; !ok {
@@ -176,6 +187,7 @@ func unpair() {
 			// validate workload assignment
 			if (val.Workloads != nil && len(illumioapi.PtrToVal(val.Workloads)) != 1) || val.Workloads == nil {
 				utils.LogWarningf(true, "csv line %d - %s has invalid workload assignment. skipping", i+1, val.Href)
+				continue
 			}
 
 			// validate heartbeat
@@ -193,6 +205,18 @@ func unpair() {
 
 			// Add to the slice
 			vensToUnpair = append(vensToUnpair, illumioapi.VEN{Href: val.Href})
+
+			// Build CSV row
+			csvRow := []string{illumioapi.PtrToVal(wkld.Hostname), wkld.Href, val.Href}
+			for _, key := range labelKeys {
+				csvRow = append(csvRow, wkld.GetLabelByKey(key, pce.Labels).Value)
+			}
+			lastHB := ""
+			if wkld.Agent != nil && wkld.Agent.Status != nil {
+				lastHB = wkld.Agent.Status.LastHeartbeatOn
+			}
+			csvRow = append(csvRow, lastHB, fmt.Sprintf("%.1f", val.HoursSinceLastHeartBeat()))
+			csvData = append(csvData, csvRow)
 		}
 	}
 
@@ -204,6 +228,10 @@ func unpair() {
 		}
 		return
 	}
+
+	// Write the unpair CSV
+	outputFileName := fmt.Sprintf("workloader-unpair-%s.csv", time.Now().Format("20060102_150405"))
+	utils.WriteOutput(csvData, csvData, outputFileName)
 
 	// If updatePCE is disabled, we are just going to alert the user what will happen and log
 	if !updatePCE {


### PR DESCRIPTION
## Summary
- Fixes #134: Re-adds the `workloader-unpair-<timestamp>.csv` file that was removed during the unpair refactor in commit cea586d
- The CSV includes: `hostname`, `href`, `ven_href`, label columns (from label dimensions), `last_heartbeat`, and `hours_since_last_heartbeat`
- The CSV is generated for all identified VENs regardless of `--update-pce` flag, so users can review before committing to the unpair

## Test plan
- [ ] Run `unpair` with a `--label-file` and verify a `workloader-unpair-<timestamp>.csv` file is created
- [ ] Verify the CSV contains the expected columns and data
- [ ] Verify the CSV is generated both with and without `--update-pce`

🤖 Generated with [Claude Code](https://claude.com/claude-code)