### PR TITLE
fix: prevent ARM/ARM64 panic from unsafe viper type assertions

### DIFF
--- a/utils/pce.go
+++ b/utils/pce.go
@@ -14,10 +14,10 @@ func GetTargetPCE(GetLabelMaps bool) (illumioapi.PCE, error) {
 
 	// Get the PCE name
 	var name string
-	if viper.Get("target_pce") != nil && viper.Get("target_pce").(string) != "" {
-		name = viper.Get("target_pce").(string)
-	} else if viper.Get("default_pce_name") != nil && viper.Get("default_pce_name").(string) != "" {
-		name = viper.Get("default_pce_name").(string)
+	if viper.GetString("target_pce") != "" {
+		name = viper.GetString("target_pce")
+	} else if viper.GetString("default_pce_name") != "" {
+		name = viper.GetString("default_pce_name")
 	} else {
 		LogError("there is no pce set using the --pce flag and there is no default pce. either run workloader pce-add to add your first pce or workloader set-default to set an existing PCE as default.")
 	}
@@ -61,9 +61,17 @@ func GetTargetPCE(GetLabelMaps bool) (illumioapi.PCE, error) {
 func GetPCEbyName(name string, GetLabelMaps bool) (illumioapi.PCE, error) {
 	var pce illumioapi.PCE
 	if viper.IsSet(name + ".fqdn") {
-		pce = illumioapi.PCE{FriendlyName: name, FQDN: viper.Get(name + ".fqdn").(string), Port: viper.Get(name + ".port").(int), Org: viper.Get(name + ".org").(int), User: viper.Get(name + ".user").(string), Key: viper.Get(name + ".key").(string), DisableTLSChecking: viper.Get(name + ".disableTLSChecking").(bool)}
-		if viper.Get(name+".proxy") != nil {
-			pce.Proxy = viper.Get(name + ".proxy").(string)
+		pce = illumioapi.PCE{
+			FriendlyName:       name,
+			FQDN:               viper.GetString(name + ".fqdn"),
+			Port:               viper.GetInt(name + ".port"),
+			Org:                viper.GetInt(name + ".org"),
+			User:               viper.GetString(name + ".user"),
+			Key:                viper.GetString(name + ".key"),
+			DisableTLSChecking: viper.GetBool(name + ".disableTLSChecking"),
+		}
+		if viper.GetString(name+".proxy") != "" {
+			pce.Proxy = viper.GetString(name + ".proxy")
 		}
 		if GetLabelMaps {
 			apiResps, err := pce.Load(illumioapi.LoadInput{Labels: true})
@@ -82,9 +90,17 @@ func GetPCEbyName(name string, GetLabelMaps bool) (illumioapi.PCE, error) {
 func GetPCENoAPI(name string) (illumioapi.PCE, error) {
 	var pce illumioapi.PCE
 	if viper.IsSet(name + ".fqdn") {
-		pce = illumioapi.PCE{FriendlyName: name, FQDN: viper.Get(name + ".fqdn").(string), Port: viper.Get(name + ".port").(int), Org: viper.Get(name + ".org").(int), User: viper.Get(name + ".user").(string), Key: viper.Get(name + ".key").(string), DisableTLSChecking: viper.Get(name + ".disableTLSChecking").(bool)}
-		if viper.Get(name+".proxy") != nil {
-			pce.Proxy = viper.Get(name + ".proxy").(string)
+		pce = illumioapi.PCE{
+			FriendlyName:       name,
+			FQDN:               viper.GetString(name + ".fqdn"),
+			Port:               viper.GetInt(name + ".port"),
+			Org:                viper.GetInt(name + ".org"),
+			User:               viper.GetString(name + ".user"),
+			Key:                viper.GetString(name + ".key"),
+			DisableTLSChecking: viper.GetBool(name + ".disableTLSChecking"),
+		}
+		if viper.GetString(name+".proxy") != "" {
+			pce.Proxy = viper.GetString(name + ".proxy")
 		}
 		return pce, nil
 	}
@@ -93,7 +109,7 @@ func GetPCENoAPI(name string) (illumioapi.PCE, error) {
 }
 
 func UseMulti() bool {
-	if viper.Get("get_api_behavior") == nil || viper.Get("get_api_behavior").(string) == "multi" {
+	if !viper.IsSet("get_api_behavior") || viper.GetString("get_api_behavior") == "multi" {
 		LogInfo("using multi get api behavior", false)
 		return true
 	}

--- a/utils/pcev2.go
+++ b/utils/pcev2.go
@@ -14,10 +14,10 @@ func GetTargetPCEV2(GetLabelMaps bool) (illumioapi.PCE, error) {
 
 	// Get the PCE name
 	var name string
-	if viper.Get("target_pce") != nil && viper.Get("target_pce").(string) != "" {
-		name = viper.Get("target_pce").(string)
-	} else if viper.Get("default_pce_name") != nil && viper.Get("default_pce_name").(string) != "" {
-		name = viper.Get("default_pce_name").(string)
+	if viper.GetString("target_pce") != "" {
+		name = viper.GetString("target_pce")
+	} else if viper.GetString("default_pce_name") != "" {
+		name = viper.GetString("default_pce_name")
 	} else {
 		LogError("there is no pce set using the --pce flag and there is no default pce. either run workloader pce-add to add your first pce or workloader set-default to set an existing PCE as default.")
 	}
@@ -61,9 +61,17 @@ func GetTargetPCEV2(GetLabelMaps bool) (illumioapi.PCE, error) {
 func GetPCEbyNameV2(name string, GetLabelMaps bool) (illumioapi.PCE, error) {
 	var pce illumioapi.PCE
 	if viper.IsSet(name + ".fqdn") {
-		pce = illumioapi.PCE{FriendlyName: name, FQDN: viper.Get(name + ".fqdn").(string), Port: viper.Get(name + ".port").(int), Org: viper.Get(name + ".org").(int), User: viper.Get(name + ".user").(string), Key: viper.Get(name + ".key").(string), DisableTLSChecking: viper.Get(name + ".disableTLSChecking").(bool)}
-		if viper.Get(name+".proxy") != nil {
-			pce.Proxy = viper.Get(name + ".proxy").(string)
+		pce = illumioapi.PCE{
+			FriendlyName:       name,
+			FQDN:               viper.GetString(name + ".fqdn"),
+			Port:               viper.GetInt(name + ".port"),
+			Org:                viper.GetInt(name + ".org"),
+			User:               viper.GetString(name + ".user"),
+			Key:                viper.GetString(name + ".key"),
+			DisableTLSChecking: viper.GetBool(name + ".disableTLSChecking"),
+		}
+		if viper.GetString(name+".proxy") != "" {
+			pce.Proxy = viper.GetString(name + ".proxy")
 		}
 		if GetLabelMaps {
 			apiResp, err := pce.GetLabels(nil)


### PR DESCRIPTION
## Summary
- Replaces all `viper.Get(...).(type)` calls in `utils/pce.go` and `utils/pcev2.go` with safe `viper.GetString()`, `viper.GetInt()`, and `viper.GetBool()` methods
- These safe methods return zero-value defaults for missing/nil config keys instead of panicking
- Also fixes the same pattern in `GetPCEbyName`, `GetPCENoAPI`, and `UseMulti` functions

## Root Cause
When a config key like `disableTLSChecking` is not set in `pce.yaml`, `viper.Get()` returns `nil`. The subsequent type assertion `nil.(bool)` causes a panic: `interface conversion: interface {} is nil, not bool`. This is more likely to occur on ARM/ARM64 where users may have minimal configs.

## Test plan
- [x] `go build` and `go vet` pass for the `utils` package
- [ ] Verify workloader runs on ARM64 with a minimal pce.yaml (no `disableTLSChecking` key)
- [ ] Verify workloader runs on amd64 with full pce.yaml (no regression)

Fixes #120

🤖 Generated with [Claude Code](https://claude.com/claude-code)