### PR TITLE
fix: use 88-day rolling window for mislabel traffic queries

### DIFF
--- a/cmd/mislabel/mislabel.go
+++ b/cmd/mislabel/mislabel.go
@@ -130,8 +130,9 @@ func misLabel() {
 	}
 
 	// Build the traffic query struct
+	// Use 88-day window (PCE max is 90 days) instead of hardcoded 2013 start date
 	tq := illumioapi.TrafficQuery{
-		StartTime:                       time.Date(2013, 1, 1, 0, 0, 0, 0, time.UTC),
+		StartTime:                       time.Now().AddDate(0, 0, -88).In(time.UTC),
 		EndTime:                         time.Now(),
 		PolicyStatuses:                  []string{"allowed", "potentially_blocked", "blocked"},
 		PortProtoExclude:                exclPorts,


### PR DESCRIPTION
## Summary
- Replaces hardcoded `time.Date(2013, 1, 1, ...)` start date with `time.Now().AddDate(0, 0, -88)` (88-day rolling window)
- The PCE traffic API enforces a 90-day maximum query range; the old 2013 date created a 10+ year span causing a 406 error
- 88 days matches the default used by the `traffic` command

## Root Cause
The mislabel command's Explorer/traffic query used a fixed start date of January 1, 2013. As time passes, this date range grows beyond the PCE's 90-day limit, causing all mislabel queries to fail with HTTP 406 "Input validation failed: invalid time range".

## Test plan
- [ ] Run `workloader mislabel` and verify no 406 error
- [ ] Verify traffic data is returned for the 88-day window

Fixes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)