### PR TITLE
fix: remove broken Network field reference in nic-export

### DIFF
--- a/cmd/nicexport/nicexport.go
+++ b/cmd/nicexport/nicexport.go
@@ -70,12 +70,7 @@ func nicExport() {
 			} else {
 				cidr = fmt.Sprintf("%s/%d", i.Address, *i.CidrBlock)
 			}
-			// Interface network name
-			netName := ""
-			if i.Network != nil {
-				netName = i.Network.Name
-			}
-			data = append(data, []string{w.Hostname, w.Href, w.GetMode(), i.Name, strconv.FormatBool(ignored), i.Address, cidr, w.GetNetMask(i.Address), i.DefaultGatewayAddress, netName})
+			data = append(data, []string{w.Hostname, w.Href, w.GetMode(), i.Name, strconv.FormatBool(ignored), i.Address, cidr, w.GetNetMask(i.Address), i.DefaultGatewayAddress})
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Removes reference to `i.Network` in `cmd/nicexport/nicexport.go` which does not exist on the `illumioapi.Interface` struct (neither v1 nor v2)
- This was introduced in commit 38f8a29 (PR #133) but caused a compile error on all platforms
- Also fixes a column mismatch: the header had 9 columns but data rows had 10

## Root Cause
The `Interface` struct in `github.com/brian1917/illumioapi` does not include a `Network` field. The PCE API may return this data, but the Go library doesn't capture it. The feature needs a library update before it can be implemented.

## Test plan
- [x] `go build ./...` passes (was previously broken)
- [x] `go vet ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)