### PR TITLE
fix: replace all unsafe viper type assertions across codebase

### DIFF
--- a/cmd/adgroupimport/cmd.go
+++ b/cmd/adgroupimport/cmd.go
@@ -57,8 +57,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		csvFile = args[0]
 
 		// Get the viper values
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		ImportADGroups(pce, csvFile, updatePCE, noPrompt)
 	},
@@ -157,7 +157,7 @@ func ImportADGroups(pce illumioapi.PCE, inputFile string, updatePCE, noPrompt bo
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d ad groups and update %d ad groups in %s (%s). Do you want to run the import (yes/no)? ", len(adGroupsToCreate), len(adGroupsToUpdate), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d ad groups and update %d ad groups in %s (%s). Do you want to run the import (yes/no)? ", len(adGroupsToCreate), len(adGroupsToUpdate), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/awslabel/cmd.go
+++ b/cmd/awslabel/cmd.go
@@ -59,8 +59,8 @@ It is recommend to run without --update-pce first to the csv produced and simula
 			utils.LogError(fmt.Sprintf("error getting pce - %s", err.Error()))
 		}
 
-		updatePCE := viper.Get("update_pce").(bool)
-		noPrompt := viper.Get("no_prompt").(bool)
+		updatePCE := viper.GetBool("update_pce")
+		noPrompt := viper.GetBool("no_prompt")
 
 		AwsLabels(labelMapping, &pce, updatePCE, noPrompt)
 	},

--- a/cmd/azurelabel/cmd.go
+++ b/cmd/azurelabel/cmd.go
@@ -56,8 +56,8 @@ It is recommend to run without --update-pce first to the csv produced and what i
 			utils.LogError(fmt.Sprintf("error getting pce - %s", err.Error()))
 		}
 
-		updatePCE := viper.Get("update_pce").(bool)
-		noPrompt := viper.Get("no_prompt").(bool)
+		updatePCE := viper.GetBool("update_pce")
+		noPrompt := viper.GetBool("no_prompt")
 
 		AzureLabels(labelMapping, &pce, updatePCE, noPrompt)
 	},

--- a/cmd/azurenetwork/cmd.go
+++ b/cmd/azurenetwork/cmd.go
@@ -52,8 +52,8 @@ It is recommend to run without --update-pce first to the csv produced and what i
 			utils.LogError(fmt.Sprintf("error getting pce - %s", err.Error()))
 		}
 
-		updatePCE := viper.Get("update_pce").(bool)
-		noPrompt := viper.Get("no_prompt").(bool)
+		updatePCE := viper.GetBool("update_pce")
+		noPrompt := viper.GetBool("no_prompt")
 
 		AzureNetworks(&pce, provision, updatePCE, noPrompt)
 	},

--- a/cmd/ccupdate/cmd.go
+++ b/cmd/ccupdate/cmd.go
@@ -51,8 +51,8 @@ When enforcement-state sent to "unmanaged":
 		containerCluster = args[0]
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		// Get the PCE
 		pce, err := utils.GetTargetPCEV2(true)
@@ -210,7 +210,7 @@ func ContainerClusterUpdate(originalPce illumioapi.PCE, containerClusterName str
 			// If updatePCE is set, but not noPrompt, we will prompt the user.
 			if updatePCE && !noPrompt {
 				var prompt string
-				fmt.Printf("[PROMPT] - workloader will update the %s pairing profile in %s (%s). Do you want to run the import (yes/no)? ", pairingProfileName, pairingProfilePce.FriendlyName, viper.Get(pairingProfilePce.FriendlyName+".fqdn").(string))
+				fmt.Printf("[PROMPT] - workloader will update the %s pairing profile in %s (%s). Do you want to run the import (yes/no)? ", pairingProfileName, pairingProfilePce.FriendlyName, viper.GetString(pairingProfilePce.FriendlyName+".fqdn"))
 
 				fmt.Scanln(&prompt)
 				if strings.ToLower(prompt) != "yes" {

--- a/cmd/containmentswitch/cmd.go
+++ b/cmd/containmentswitch/cmd.go
@@ -71,8 +71,8 @@ The --update-pce flag is required for Steps 2 through 7. If the --update-pce fla
 		}
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		portLock(targetPort, args[1])
 	},
@@ -180,7 +180,7 @@ func portLock(port int, protocol string) {
 			}
 
 			var prompt string
-			fmt.Printf("\r\n%s[PROMPT] - workloader will do the following in %s (%s):\r\n", time.Now().Format("2006-01-02 15:04:05 "), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+			fmt.Printf("\r\n%s[PROMPT] - workloader will do the following in %s (%s):\r\n", time.Now().Format("2006-01-02 15:04:05 "), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 			for i, c := range changes {
 				fmt.Printf("%s [PROMPT] - %d) %s\r\n", time.Now().Format("2006-01-02 15:04:05"), i+1, c)
 			}

--- a/cmd/cspiplist/cmd.go
+++ b/cmd/cspiplist/cmd.go
@@ -62,8 +62,8 @@ By default no changes will be made to the PCE.  Please use --update-pce if you w
 			utils.LogError(fmt.Sprintf("error getting pce - %s", err.Error()))
 		}
 
-		updatePCE := viper.Get("update_pce").(bool)
-		noPrompt := viper.Get("no_prompt").(bool)
+		updatePCE := viper.GetBool("update_pce")
+		noPrompt := viper.GetBool("no_prompt")
 
 		// Set the CSV file
 		if len(args) > 1 {

--- a/cmd/cwpimport/cmd.go
+++ b/cmd/cwpimport/cmd.go
@@ -47,8 +47,8 @@ Only label assignments are supported. Label restrictions will show as blank in t
 		importFile = args[0]
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		// Validate remove value
 		if removeValueInput == "" {
@@ -316,7 +316,7 @@ func ImportContainerProfiles(pce illumioapi.PCE, importFile, removeValue string,
 	// Prompt
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("\r\n%s [PROMPT] - do you want to run the import to %s (%s) (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n%s [PROMPT] - do you want to run the import to %s (%s) (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied", true)

--- a/cmd/dagsync/cmd.go
+++ b/cmd/dagsync/cmd.go
@@ -163,7 +163,7 @@ The --update-pce flag is ignored for this command. The --update-panos flag is us
 		}
 
 		// Get the viper values
-		noPrompt = viper.Get("no_prompt").(bool)
+		noPrompt = viper.GetBool("no_prompt")
 
 		dagSync()
 	},

--- a/cmd/deletehrefs/delete.go
+++ b/cmd/deletehrefs/delete.go
@@ -51,8 +51,8 @@ Delete any object with an HREF (e.g., unmanaged workloads, labels, services, IPL
 		input.getHrefs(args[0])
 
 		// Get persistent flags from Viper
-		input.UpdatePCE = viper.Get("update_pce").(bool)
-		input.NoPrompt = viper.Get("no_prompt").(bool)
+		input.UpdatePCE = viper.GetBool("update_pce")
+		input.NoPrompt = viper.GetBool("no_prompt")
 
 		DeleteHrefs(input)
 	},
@@ -161,7 +161,7 @@ func DeleteHrefs(input Input) {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if input.UpdatePCE && !input.NoPrompt {
 		var prompt string
-		fmt.Printf("\r\n[PROMPT] - workloader identified %d objects to attempt to delete in %s (%s). Do you want to run the delete (yes/no)? ", len(input.Hrefs), input.PCE.FriendlyName, viper.Get(input.PCE.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n[PROMPT] - workloader identified %d objects to attempt to delete in %s (%s). Do you want to run the delete (yes/no)? ", len(input.Hrefs), input.PCE.FriendlyName, viper.GetString(input.PCE.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied.", true)

--- a/cmd/denyruleimport/cmd.go
+++ b/cmd/denyruleimport/cmd.go
@@ -73,8 +73,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		cmdInput.ImportFile = args[0]
 
 		// Get the debug value from viper
-		cmdInput.UpdatePCE = viper.Get("update_pce").(bool)
-		cmdInput.NoPrompt = viper.Get("no_prompt").(bool)
+		cmdInput.UpdatePCE = viper.GetBool("update_pce")
+		cmdInput.NoPrompt = viper.GetBool("no_prompt")
 
 		ImportBoundariesFromCSV(cmdInput)
 	},
@@ -421,7 +421,7 @@ func ImportBoundariesFromCSV(input Input) {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if input.UpdatePCE && !input.NoPrompt {
 		var prompt string
-		fmt.Printf("\r\n[PROMPT] - workloader identified %d boundaries to create and %d boundaries to update in %s (%s). do you want to run the import (yes/no)? ", len(newBoundaries), len(updatedBoundaries), input.PCE.FriendlyName, viper.Get(input.PCE.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n[PROMPT] - workloader identified %d boundaries to create and %d boundaries to update in %s (%s). do you want to run the import (yes/no)? ", len(newBoundaries), len(updatedBoundaries), input.PCE.FriendlyName, viper.GetString(input.PCE.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied.", true)

--- a/cmd/findfqdn/cmd.go
+++ b/cmd/findfqdn/cmd.go
@@ -49,8 +49,8 @@ The update-pce and --no-prompt flags are ignored for this command.`,
 		// Get the workloads
 		pce.Load(illumioapi.LoadInput{Workloads: true}, utils.UseMulti())
 
-		updatePCE := viper.Get("update_pce").(bool)
-		noPrompt := viper.Get("no_prompt").(bool)
+		updatePCE := viper.GetBool("update_pce")
+		noPrompt := viper.GetBool("no_prompt")
 
 		FindFQDN(&pce, updatePCE, noPrompt)
 	},

--- a/cmd/gcplabel/cmd.go
+++ b/cmd/gcplabel/cmd.go
@@ -49,8 +49,8 @@ It is recommend to run without --update-pce first to the csv produced and what i
 			utils.LogError(fmt.Sprintf("error getting pce - %s", err.Error()))
 		}
 
-		updatePCE := viper.Get("update_pce").(bool)
-		noPrompt := viper.Get("no_prompt").(bool)
+		updatePCE := viper.GetBool("update_pce")
+		noPrompt := viper.GetBool("no_prompt")
 
 		GCPLabels(labelMapping, &pce, updatePCE, noPrompt)
 	},

--- a/cmd/hostparse/hostparse.go
+++ b/cmd/hostparse/hostparse.go
@@ -67,9 +67,9 @@ An input CSV specifics the regex functions to use to assign labels. An example i
 		}
 
 		// Get persistent flags from Viper
-		debug = viper.Get("debug").(bool)
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		debug = viper.GetBool("debug")
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		// Get CSV file
 		if len(args) != 1 {
@@ -488,7 +488,7 @@ func hostnameParser() {
 		if noPrompt {
 			response = "yes"
 		} else if updatePCE {
-			fmt.Printf("Do you want to update Workloads and potentially create new labels in %s (%s) (yes/no)? ", pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+			fmt.Printf("Do you want to update Workloads and potentially create new labels in %s (%s) (yes/no)? ", pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 			fmt.Scanln(&response)
 		} else {
 			fmt.Println("List of ALL Regex Matched Hostnames even if no Workload exist on the PCE. ")

--- a/cmd/increasevenupdaterate/cmd.go
+++ b/cmd/increasevenupdaterate/cmd.go
@@ -52,8 +52,8 @@ The forMinutes flag can be used to have workloader run the command every 10 minu
 		}
 
 		// Get Viper configuration
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		increaseVENUpdateRate()
 	},
@@ -101,7 +101,7 @@ func increaseVENUpdateRate() {
 
 	// If updatePCE is disabled, we are just going to alert the user what will happen and log
 	if !updatePCE {
-		utils.LogInfo(fmt.Sprintf("workloader identified %d workloads requiring VEN update rate incease in %s (%s). To update, run again using --update-pce flag. The --no-prompt flag will bypass the prompt if used with --update-pce.", len(pce.WorkloadsSlice), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string)), true)
+		utils.LogInfo(fmt.Sprintf("workloader identified %d workloads requiring VEN update rate incease in %s (%s). To update, run again using --update-pce flag. The --no-prompt flag will bypass the prompt if used with --update-pce.", len(pce.WorkloadsSlice), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn")), true)
 
 		return
 	}

--- a/cmd/iplimport/iplimport.go
+++ b/cmd/iplimport/iplimport.go
@@ -74,9 +74,9 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		csvFile = args[0]
 
 		// Get the viper values
-		debug = viper.Get("debug").(bool)
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		debug = viper.GetBool("debug")
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		ImportIPLists(pce, csvFile, updatePCE, noPrompt, debug, provision)
 	},
@@ -378,7 +378,7 @@ csvEntries:
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d iplists and update %d iplists in %s (%s). do you want to run the import (yes/no)? ", len(IPLsToCreate), len(IPLsToUpdate), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d iplists and update %d iplists in %s (%s). do you want to run the import (yes/no)? ", len(IPLsToCreate), len(IPLsToUpdate), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/iplreplace/cmd.go
+++ b/cmd/iplreplace/cmd.go
@@ -77,8 +77,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		iplName = args[0]
 
 		// Get the viper values
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		IplReplace(Input{
 			PCE:         pce,
@@ -202,9 +202,9 @@ func IplReplace(input Input) {
 	if input.UpdatePCE && !input.NoPrompt {
 		var prompt string
 		if iplToBeCreated {
-			fmt.Printf("[PROMPT] - workloader will create %s ip list with %d ip entries and %d in %s(%s). do you want to run the import (yes/no)? ", input.IplName, ipCount, fqdnCount, pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+			fmt.Printf("[PROMPT] - workloader will create %s ip list with %d ip entries and %d in %s(%s). do you want to run the import (yes/no)? ", input.IplName, ipCount, fqdnCount, pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 		} else {
-			fmt.Printf("[PROMPT] - workloader identified %d ip entries and %d fqdn entries to replace the existing %d ip entries and %d fqdn entries in %s ip list in %s(%s). do you want to run the import (yes/no)? ", ipCount, fqdnCount, len(*pceIPL.IPRanges), len(*pceIPL.FQDNs), pceIPL.Name, pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+			fmt.Printf("[PROMPT] - workloader identified %d ip entries and %d fqdn entries to replace the existing %d ip entries and %d fqdn entries in %s ip list in %s(%s). do you want to run the import (yes/no)? ", ipCount, fqdnCount, len(*pceIPL.IPRanges), len(*pceIPL.FQDNs), pceIPL.Name, pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 		}
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/labeldimension/import.go
+++ b/cmd/labeldimension/import.go
@@ -56,8 +56,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		csvFile = args[0]
 
 		// Get the viper values
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		ImportLabelDimensions(&pce, csvFile, updatePCE, noPrompt)
 	},
@@ -184,7 +184,7 @@ func ImportLabelDimensions(pce *illumioapi.PCE, inputFile string, updatePCE, noP
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d labels and update %d labels in %s (%s). Do you want to run the import (yes/no)? ", len(newLabelDimensions), len(updateLabelDimensions), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d labels and update %d labels in %s (%s). Do you want to run the import (yes/no)? ", len(newLabelDimensions), len(updateLabelDimensions), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/labelgroupimport/labelgroupimport.go
+++ b/cmd/labelgroupimport/labelgroupimport.go
@@ -70,8 +70,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		csvFile = args[0]
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		labelGroupImport()
 	},
@@ -338,7 +338,7 @@ CSVEntries:
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d label groups and update %d label groups in %s (%s). Do you want to run the import (yes/no)? ", len(newLabelGroups), len(updatedLabelGroups), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d label groups and update %d label groups in %s (%s). Do you want to run the import (yes/no)? ", len(newLabelGroups), len(updatedLabelGroups), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/labelimport/cmd.go
+++ b/cmd/labelimport/cmd.go
@@ -68,8 +68,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		csvFile = args[0]
 
 		// Get the viper values
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		ImportLabels(pce, csvFile, updatePCE, noPrompt)
 	},
@@ -218,7 +218,7 @@ func ImportLabels(pce illumioapi.PCE, inputFile string, updatePCE, noPrompt bool
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d labels and update %d labels in %s (%s). Do you want to run the import (yes/no)? ", len(labelsToCreate), len(labelsToUpdate), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d labels and update %d labels in %s (%s). Do you want to run the import (yes/no)? ", len(labelsToCreate), len(labelsToUpdate), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/mislabel/mislabel.go
+++ b/cmd/mislabel/mislabel.go
@@ -54,7 +54,7 @@ The --update-pce and --no-prompt flags are ignored for this command.`,
 		}
 
 		// Get the debug value from viper
-		debug = viper.Get("debug").(bool)
+		debug = viper.GetBool("debug")
 
 		misLabel()
 	},

--- a/cmd/nen/nen-switch.go
+++ b/cmd/nen/nen-switch.go
@@ -66,8 +66,8 @@ switchinterface, href(optional), name, interface, label#1, label#2, label#3, etc
 		if createUMWL {
 			// Get the services
 			// Get the debug value from viper
-			input.UpdatePCE = viper.Get("update_pce").(bool)
-			input.NoPrompt = viper.Get("no_prompt").(bool)
+			input.UpdatePCE = viper.GetBool("update_pce")
+			input.NoPrompt = viper.GetBool("no_prompt")
 			input.Umwl = true
 			input.MaxCreate = -1
 			input.MaxUpdate = -1

--- a/cmd/netscalersync/cmd.go
+++ b/cmd/netscalersync/cmd.go
@@ -50,8 +50,8 @@ Recommended to run without --update-pce first to log of what will change.`,
 			utils.LogError(err.Error())
 		}
 
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		utils.LogWarning("this command has been marked for deprecation. please open an issue on GitHub if you use it and want it preserved.", true)
 

--- a/cmd/netscalersync/nssync.go
+++ b/cmd/netscalersync/nssync.go
@@ -165,7 +165,7 @@ func nsSync(pce illumioapi.PCE, netscaler ns.NetScaler) {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("\r\n%s [PROMPT] - workloader will create %d virtual services (vips), create %d unmanaged workloads (snips), update %d virtual services (vips), update %d unmanaged workloads (snips), remove %d virtual services (vips), and remove %d unmanaged workloads (snips) in %s (%s). do you want to run the import (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), len(createVirtualServices), len(createUMWLs), len(updateVirtualServices), len(updateUMWLs), len(removeVirtualServices), len(removeUMWLs), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n%s [PROMPT] - workloader will create %d virtual services (vips), create %d unmanaged workloads (snips), update %d virtual services (vips), update %d unmanaged workloads (snips), remove %d virtual services (vips), and remove %d unmanaged workloads (snips) in %s (%s). do you want to run the import (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), len(createVirtualServices), len(createUMWLs), len(updateVirtualServices), len(updateUMWLs), len(removeVirtualServices), len(removeUMWLs), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied.", true)

--- a/cmd/nicmanage/nicmanage.go
+++ b/cmd/nicmanage/nicmanage.go
@@ -38,8 +38,8 @@ Head input CSV requires a header row with at least two headers: wkld_href and ig
 		}
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		// Set the CSV file
 		if len(args) != 1 {
@@ -178,7 +178,7 @@ func nicManage() {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("\r\n%s [PROMPT] - Do you want to run the import to %s at %s (yes/no)?", time.Now().Format("2006-01-02 15:04:05 "), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n%s [PROMPT] - Do you want to run the import to %s at %s (yes/no)?", time.Now().Format("2006-01-02 15:04:05 "), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo(fmt.Sprintf("prompt denied to update %d workloads.", len(updatedWklds)), true)

--- a/cmd/pcemgmt/addtenant.go
+++ b/cmd/pcemgmt/addtenant.go
@@ -91,12 +91,12 @@ func GetTenantByName(name string) (tenant illumiocloudapi.Tenant, err error) {
 		return tenant, fmt.Errorf("could not retrieve valid tenant because tenant id is blank for %s", name)
 	}
 	tenant.FriendlyName = name
-	tenant.TenantID = viper.Get(name + ".tenant_id").(string)
+	tenant.TenantID = viper.GetString(name + ".tenant_id")
 	if viper.IsSet(name + ".client_id") {
-		tenant.ClientID = viper.Get(name + ".client_id").(string)
+		tenant.ClientID = viper.GetString(name + ".client_id")
 	}
 	if viper.IsSet(name + ".client_secret") {
-		tenant.Secret = viper.Get(name + ".client_secret").(string)
+		tenant.Secret = viper.GetString(name + ".client_secret")
 	}
 	return tenant, nil
 }

--- a/cmd/pcemgmt/defaultpce.go
+++ b/cmd/pcemgmt/defaultpce.go
@@ -26,17 +26,17 @@ var PCEListCmd = &cobra.Command{
 
 		defaultPCEName := ""
 		if viper.Get("default_pce_name") != nil {
-			defaultPCEName = viper.Get("default_pce_name").(string)
+			defaultPCEName = viper.GetString("default_pce_name")
 		}
 
 		count := 0
 		for k := range allSettings {
 			if viper.Get(k+".fqdn") != nil {
 				if k == defaultPCEName {
-					fmt.Printf("* %s (%s)\r\n", k, viper.Get(k+".fqdn").(string))
+					fmt.Printf("* %s (%s)\r\n", k, viper.GetString(k+".fqdn"))
 					count++
 				} else {
-					fmt.Printf("  %s (%s)\r\n", k, viper.Get(k+".fqdn").(string))
+					fmt.Printf("  %s (%s)\r\n", k, viper.GetString(k+".fqdn"))
 					count++
 				}
 			}

--- a/cmd/pcemgmt/removepce.go
+++ b/cmd/pcemgmt/removepce.go
@@ -60,7 +60,7 @@ func removePce() {
 		}
 
 		// Get all API Keys
-		apiKeys, _, err := pce.GetAllAPIKeys(viper.Get(pceName + ".userhref").(string))
+		apiKeys, _, err := pce.GetAllAPIKeys(viper.GetString(pceName + ".userhref"))
 		if err != nil {
 			utils.LogError(err.Error())
 		}
@@ -69,7 +69,7 @@ func removePce() {
 		saveHref := ""
 		for _, a := range apiKeys {
 			if a.Name == "workloader" && a.Description == "created by workloader" {
-				if a.AuthUsername != viper.Get(pceName+".user").(string) {
+				if a.AuthUsername != viper.GetString(pceName+".user") {
 					_, err := pce.DeleteHref(a.Href)
 					if err != nil {
 						utils.LogError(err.Error())

--- a/cmd/permissionsimport/cmd.go
+++ b/cmd/permissionsimport/cmd.go
@@ -56,7 +56,7 @@ Valid role options include the following:
 			os.Exit(0)
 		}
 
-		importPermissions(pce, args[0], viper.Get("update_pce").(bool), viper.Get("no_prompt").(bool))
+		importPermissions(pce, args[0], viper.GetBool("update_pce"), viper.GetBool("no_prompt"))
 	},
 }
 
@@ -194,7 +194,7 @@ func importPermissions(pce illumioapi.PCE, csvFile string, updatePCE, noPrompt b
 
 	if !noPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d permissions and update %d permissions in %s (%s). Do you want to run the import (yes/no)? ", len(newPermissions), len(updatedPermissions), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d permissions and update %d permissions in %s (%s). Do you want to run the import (yes/no)? ", len(newPermissions), len(updatedPermissions), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/ruleimport/ruleimport.go
+++ b/cmd/ruleimport/ruleimport.go
@@ -101,8 +101,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		globalInput.ImportFile = args[0]
 
 		// Get the debug value from viper
-		globalInput.UpdatePCE = viper.Get("update_pce").(bool)
-		globalInput.NoPrompt = viper.Get("no_prompt").(bool)
+		globalInput.UpdatePCE = viper.GetBool("update_pce")
+		globalInput.NoPrompt = viper.GetBool("no_prompt")
 
 		ImportRulesFromCSV(globalInput)
 	},
@@ -994,7 +994,7 @@ CSVEntries:
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if input.UpdatePCE && !input.NoPrompt {
 		var prompt string
-		fmt.Printf("\r\n[PROMPT] - workloader identified %d rules to create and %d rules to update in %s (%s). Do you want to run the import (yes/no)? ", len(newRules), len(updatedRules), input.PCE.FriendlyName, viper.Get(input.PCE.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n[PROMPT] - workloader identified %d rules to create and %d rules to update in %s (%s). Do you want to run the import (yes/no)? ", len(newRules), len(updatedRules), input.PCE.FriendlyName, viper.GetString(input.PCE.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied.", true)

--- a/cmd/rulesetimport/import.go
+++ b/cmd/rulesetimport/import.go
@@ -71,8 +71,8 @@ Recommended to run without --update-pce first to log what will change.`,
 		input.ImportFile = args[0]
 
 		// Get the debug value from viper
-		input.UpdatePCE = viper.Get("update_pce").(bool)
-		input.NoPrompt = viper.Get("no_prompt").(bool)
+		input.UpdatePCE = viper.GetBool("update_pce")
+		input.NoPrompt = viper.GetBool("no_prompt")
 
 		ImportRuleSetsFromCSV(input)
 	},
@@ -257,7 +257,7 @@ csvEntries:
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if input.UpdatePCE && !input.NoPrompt {
 		var prompt string
-		fmt.Printf("\r\n[PROMPT] - workloader identified %d rulesets to create and %d rulesets to update in %s (%s). Do you want to run the import (yes/no)? ", len(newRuleSets), len(updateRuleSets), input.PCE.FriendlyName, viper.Get(input.PCE.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n[PROMPT] - workloader identified %d rulesets to create and %d rulesets to update in %s (%s). Do you want to run the import (yes/no)? ", len(newRuleSets), len(updateRuleSets), input.PCE.FriendlyName, viper.GetString(input.PCE.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied.", true)

--- a/cmd/secprincipalimport/cmd.go
+++ b/cmd/secprincipalimport/cmd.go
@@ -46,7 +46,7 @@ The following headers are required:
 			os.Exit(0)
 		}
 
-		importSecPrincipals(pce, args[0], viper.Get("update_pce").(bool), viper.Get("no_prompt").(bool))
+		importSecPrincipals(pce, args[0], viper.GetBool("update_pce"), viper.GetBool("no_prompt"))
 	},
 }
 
@@ -108,7 +108,7 @@ func importSecPrincipals(pce illumioapi.PCE, csvFile string, updatePCE, noPrompt
 
 	if !noPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d security principals in %s (%s). Do you want to run the import (yes/no)? ", len(secPrincipals), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d security principals in %s (%s). Do you want to run the import (yes/no)? ", len(secPrincipals), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/subnet/subnet.go
+++ b/cmd/subnet/subnet.go
@@ -74,8 +74,8 @@ Recommended to run without --update-pce first to log of what will change in a cs
 		csvFile = args[0]
 
 		// Get Viper configuration
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		subnetParser()
 	},

--- a/cmd/svcimport/cmd.go
+++ b/cmd/svcimport/cmd.go
@@ -69,8 +69,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		}
 
 		// Get the viper values
-		input.UpdatePCE = viper.Get("update_pce").(bool)
-		input.NoPrompt = viper.Get("no_prompt").(bool)
+		input.UpdatePCE = viper.GetBool("update_pce")
+		input.NoPrompt = viper.GetBool("no_prompt")
 
 		ImportServices(input)
 	},

--- a/cmd/svcimport/import.go
+++ b/cmd/svcimport/import.go
@@ -362,7 +362,7 @@ func ImportServices(input Input) {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if input.UpdatePCE && !input.NoPrompt {
 		var prompt string
-		fmt.Printf("[PROMPT] - workloader will create %d services and update %d services in %s (%s). Do you want to run the import (yes/no)? ", len(newServices), len(updatedServices), input.PCE.FriendlyName, viper.Get(input.PCE.FriendlyName+".fqdn").(string))
+		fmt.Printf("[PROMPT] - workloader will create %d services and update %d services in %s (%s). Do you want to run the import (yes/no)? ", len(newServices), len(updatedServices), input.PCE.FriendlyName, viper.GetString(input.PCE.FriendlyName+".fqdn"))
 
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {

--- a/cmd/templateimport/templateimport.go
+++ b/cmd/templateimport/templateimport.go
@@ -53,8 +53,8 @@ Use template-list command to see available templates.`,
 		template = args[0]
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		importTemplate()
 	},

--- a/cmd/unpair/unpair.go
+++ b/cmd/unpair/unpair.go
@@ -65,8 +65,8 @@ Use the --update-pce command to run the unpair with a user prompt confirmation. 
 		}
 
 		// Get persistent flags from Viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		unpair()
 	},
@@ -242,7 +242,7 @@ func unpair() {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("%s [PROMPT] - workloader identified %d vens requiring unpairing in %s (%s). Do you want to run the unpair? (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), len(vensToUnpair), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("%s [PROMPT] - workloader identified %d vens requiring unpairing in %s (%s). Do you want to run the unpair? (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), len(vensToUnpair), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied.", true)

--- a/cmd/upgrade/upgrade.go
+++ b/cmd/upgrade/upgrade.go
@@ -53,8 +53,8 @@ Default output is a CSV file with what would be upgraded. Use the --update-pce c
 		}
 
 		// Get persistent flags from Viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		wkldUpgrade()
 	},
@@ -210,7 +210,7 @@ func wkldUpgrade() {
 		// If updatePCE is set, but not noPrompt, we will prompt the user.
 		if updatePCE && !noPrompt {
 			var prompt string
-			fmt.Printf("[PROMPT] - workloader identified %d workloads in %s (%s) requiring VEN updates. See %s for details. Do you want to run the upgrade? (yes/no)? ", len(targetVENs), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string), outputFileName)
+			fmt.Printf("[PROMPT] - workloader identified %d workloads in %s (%s) requiring VEN updates. See %s for details. Do you want to run the upgrade? (yes/no)? ", len(targetVENs), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"), outputFileName)
 			fmt.Scanln(&prompt)
 			if strings.ToLower(prompt) != "yes" {
 				utils.LogInfo(fmt.Sprintf("prompt denied to upgrade %d workloads", len(targetVENs)), true)

--- a/cmd/venimport/cmd.go
+++ b/cmd/venimport/cmd.go
@@ -54,8 +54,8 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		importFile = args[0]
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		importVens()
 	},
@@ -167,7 +167,7 @@ func importVens() {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if updatePCE && !noPrompt {
 		var prompt string
-		fmt.Printf("\r\n%s [PROMPT] - %d vens requiring update in %s(%s). Do you want to run the import (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), len(vensToUpdate), pce.FriendlyName, viper.Get(pce.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n%s [PROMPT] - %d vens requiring update in %s(%s). Do you want to run the import (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), len(vensToUpdate), pce.FriendlyName, viper.GetString(pce.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo(fmt.Sprintf("prompt denied to update %d vens.", len(vensToUpdate)), true)

--- a/cmd/vmsync/cmd.go
+++ b/cmd/vmsync/cmd.go
@@ -78,8 +78,8 @@ Support VCenter version > 7.0.u2`,
 		}
 		//Get the debug value from viper
 		//debug = viper.Get("debug").(bool)
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 
 		//load keymapfile, This file will have the Catagories to Label Type mapping
 		keyMap := readKeyFile(csvFile)

--- a/cmd/wkldimport/cmd.go
+++ b/cmd/wkldimport/cmd.go
@@ -124,8 +124,8 @@ Recommended to run without --update-pce first to log what will change.`,
 		input.ImportFile = args[0]
 
 		// Get the debug value from viper
-		input.UpdatePCE = viper.Get("update_pce").(bool)
-		input.NoPrompt = viper.Get("no_prompt").(bool)
+		input.UpdatePCE = viper.GetBool("update_pce")
+		input.NoPrompt = viper.GetBool("no_prompt")
 
 		// Load the PCE with workloads
 		apiResps, err := input.PCE.Load(illumioapi.LoadInput{Workloads: true}, utils.UseMulti())

--- a/cmd/wkldimport/import.go
+++ b/cmd/wkldimport/import.go
@@ -249,7 +249,7 @@ func ImportWkldsFromCSV(input Input) {
 	// If updatePCE is set, but not noPrompt, we will prompt the user.
 	if input.UpdatePCE && !input.NoPrompt {
 		var prompt string
-		fmt.Printf("\r\n%s [PROMPT] - Do you want to run the import to %s (%s) (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), input.PCE.FriendlyName, viper.Get(input.PCE.FriendlyName+".fqdn").(string))
+		fmt.Printf("\r\n%s [PROMPT] - Do you want to run the import to %s (%s) (yes/no)? ", time.Now().Format("2006-01-02 15:04:05 "), input.PCE.FriendlyName, viper.GetString(input.PCE.FriendlyName+".fqdn"))
 		fmt.Scanln(&prompt)
 		if strings.ToLower(prompt) != "yes" {
 			utils.LogInfo("prompt denied", true)

--- a/cmd/wkldlabel/cmd.go
+++ b/cmd/wkldlabel/cmd.go
@@ -40,8 +40,8 @@ The command leverages the wkld-import command. The  workloader.log file will log
 			utils.LogError(fmt.Sprintf("error getting pce - %s", err.Error()))
 		}
 
-		updatePCE := viper.Get("update_pce").(bool)
-		noPrompt := viper.Get("no_prompt").(bool)
+		updatePCE := viper.GetBool("update_pce")
+		noPrompt := viper.GetBool("no_prompt")
 
 		LabelWkld(&pce, hostname, labels, updatePCE, noPrompt)
 	},

--- a/cmd/wkldreplicate/wkkdreplicate.go
+++ b/cmd/wkldreplicate/wkkdreplicate.go
@@ -42,8 +42,8 @@ Managed and unmanaged workloads are replicated across all PCEs. The command crea
 	Run: func(cmd *cobra.Command, args []string) {
 
 		// Get the debug value from viper
-		updatePCE = viper.Get("update_pce").(bool)
-		noPrompt = viper.Get("no_prompt").(bool)
+		updatePCE = viper.GetBool("update_pce")
+		noPrompt = viper.GetBool("no_prompt")
 		wkldReplicate()
 	},
 }

--- a/utils/log.go
+++ b/utils/log.go
@@ -18,8 +18,8 @@ func SetUpLogging() {
 
 	// First check env variable, then config file, then use default
 	logFile = os.Getenv("WORKLOADER_LOG")
-	if logFile == "" && viper.Get("log_file") != nil && viper.Get("log_file").(string) != "" {
-		logFile = viper.Get("log_file").(string)
+	if logFile == "" && viper.GetString("log_file") != "" {
+		logFile = viper.GetString("log_file")
 	} else {
 		logFile = "workloader.log"
 	}
@@ -36,7 +36,7 @@ func LogError(msg string) {
 
 	Logger.SetPrefix(time.Now().Format("2006-01-02 15:04:05 "))
 	fmt.Printf("%s [ERROR] - %s see workloader.log for potentially more information.\r\n", time.Now().Format("2006-01-02 15:04:05 "), msg)
-	if (viper.Get("continue_on_error") != nil && viper.Get("continue_on_error").(bool)) || (viper.Get("continue_on_error_default") != nil && viper.Get("continue_on_error_default").(string) == "continue") {
+	if viper.GetBool("continue_on_error") || viper.GetString("continue_on_error_default") == "continue" {
 		Logger.Printf("[ERROR] - %s\r\n", msg)
 	} else {
 		Logger.Fatalf("[ERROR] - %s\r\n", msg)
@@ -53,7 +53,7 @@ func LogErrorfCode(exitCode int, format string, a ...any) {
 	Logger.SetPrefix(time.Now().Format("2006-01-02 15:04:05 "))
 	fmt.Printf("%s [ERROR] - %s see workloader.log for potentially more information.\r\n", time.Now().Format("2006-01-02 15:04:05 "), fmt.Sprintf(format, a...))
 	Logger.Printf("[ERROR] - %s\r\n", fmt.Sprintf(format, a...))
-	if (viper.Get("continue_on_error") != nil && viper.Get("continue_on_error").(bool)) || (viper.Get("continue_on_error_default") != nil && viper.Get("continue_on_error_default").(string) == "continue") {
+	if viper.GetBool("continue_on_error") || viper.GetString("continue_on_error_default") == "continue" {
 		return
 	}
 	os.Exit(exitCode)
@@ -92,7 +92,7 @@ func LogInfof(stdout bool, format string, a ...any) {
 func LogDebug(msg string) {
 
 	// Get the debug value from viper
-	debug := viper.Get("debug").(bool)
+	debug := viper.GetBool("debug")
 
 	if debug {
 		Logger.SetPrefix(time.Now().Format("2006-01-02 15:04:05 "))
@@ -116,7 +116,7 @@ func LogAPIResp(callType string, apiResp illumioapi.APIResponse) {
 		LogInfof(true, "%s request body: %s", callType, apiResp.ReqBody)
 	}
 	LogInfo(fmt.Sprintf("%s status code: %d", callType, apiResp.StatusCode), false)
-	if viper.Get("verbose").(bool) || apiResp.StatusCode > 299 {
+	if viper.GetBool("verbose") || apiResp.StatusCode > 299 {
 		LogDebug(fmt.Sprintf("%s response body: %s", callType, apiResp.RespBody))
 	}
 
@@ -138,11 +138,11 @@ func LogStartCommand(fullCommand string) {
 	commandName := os.Args[1]
 	LogInfo(fmt.Sprintf("started %s", commandName), false)
 	LogInfof(false, "full command: %s", fullCommand)
-	if viper.IsSet("target_pce") && viper.Get("target_pce") != nil && viper.Get("target_pce").(string) != "" {
-		LogInfo(fmt.Sprintf("using %s pce - %s", viper.Get("target_pce").(string), viper.Get(viper.Get("target_pce").(string)+".pce_version")), false)
+	if viper.GetString("target_pce") != "" {
+		LogInfo(fmt.Sprintf("using %s pce - %s", viper.GetString("target_pce"), viper.Get(viper.GetString("target_pce")+".pce_version")), false)
 	} else {
-		if viper.Get("default_pce_name") != nil {
-			LogInfo(fmt.Sprintf("using default pce - %s - %s", viper.Get("default_pce_name").(string), viper.Get(viper.Get("default_pce_name").(string)+".pce_version")), false)
+		if viper.GetString("default_pce_name") != "" {
+			LogInfo(fmt.Sprintf("using default pce - %s - %s", viper.GetString("default_pce_name"), viper.Get(viper.GetString("default_pce_name")+".pce_version")), false)
 		}
 	}
 }

--- a/utils/logv2.go
+++ b/utils/logv2.go
@@ -14,7 +14,7 @@ import (
 func LogAPIRespV2(callType string, apiResp illumioapi.APIResponse) {
 
 	// Get the original logging status in case it's flipped for a non-200 status code
-	orginalDebug := viper.Get("debug").(bool)
+	orginalDebug := viper.GetBool("debug")
 
 	// If we have a bad API response, set the debug to true
 	if apiResp.StatusCode > 299 {
@@ -28,7 +28,7 @@ func LogAPIRespV2(callType string, apiResp illumioapi.APIResponse) {
 		}
 	}
 	LogInfo(fmt.Sprintf("%s response status code: %d", callType, apiResp.StatusCode), false)
-	if viper.Get("verbose").(bool) || apiResp.StatusCode > 299 {
+	if viper.GetBool("verbose") || apiResp.StatusCode > 299 {
 		LogDebug(fmt.Sprintf("%s response body: %s", callType, apiResp.RespBody))
 	}
 

--- a/utils/output.go
+++ b/utils/output.go
@@ -14,11 +14,11 @@ import (
 func WriteOutput(csvData, stdOutData [][]string, csvFileName string) {
 
 	// Get the output format
-	outFormat := viper.Get("output_format").(string)
+	outFormat := viper.GetString("output_format")
 
 	// Write stdout if output format dictates it
 	if outFormat == "stdout" || outFormat == "both" {
-		if len(stdOutData) < viper.Get("max_entries_for_stdout").(int) {
+		if len(stdOutData) < viper.GetInt("max_entries_for_stdout") {
 			table := tablewriter.NewWriter(os.Stdout)
 			table.SetHeader(stdOutData[0])
 			for i := 1; i <= len(stdOutData)-1; i++ {


### PR DESCRIPTION
## Summary
- Replaces ~100 occurrences of `viper.Get("key").(type)` with safe `viper.GetString()`, `viper.GetBool()`, `viper.GetInt()` across **47 files**
- These safe methods return zero values instead of panicking when a key is nil or has an unexpected type
- Extends the fix from PR #139 (which fixed `utils/pce.go` and `utils/pcev2.go`) to the entire codebase

## Root Cause
The `viper.Get()` function returns `interface{}`. Direct type assertions like `viper.Get("key").(bool)` panic with `interface conversion: interface {} is nil, not bool` if the key is missing. This affected every command that reads `update_pce`, `no_prompt`, `debug`, `verbose`, `output_format`, or PCE FQDN from config.

## Files Changed
- `utils/log.go`, `utils/logv2.go`, `utils/output.go` — core utility assertions
- 44 command files across `cmd/` — flag reading and prompt display assertions

## Test plan
- [x] `go vet` passes for all modified packages
- [x] No remaining `viper.Get(...).(type)` patterns (only one commented-out line in vmsync)

🤖 Generated with [Claude Code](https://claude.com/claude-code)