### PR TITLE
fix: replace deprecated io/ioutil with io and os equivalents

### DIFF
--- a/cmd/dagsync/cmd.go
+++ b/cmd/dagsync/cmd.go
@@ -6,7 +6,7 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -208,7 +208,7 @@ func httpSetUp(httpAction, apiURL string, body []byte, disableTLSChecking bool, 
 	defer resp.Body.Close()
 
 	// Process response
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
 	}

--- a/cmd/templatelist/cmd.go
+++ b/cmd/templatelist/cmd.go
@@ -2,7 +2,6 @@ package templatelist
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -37,7 +36,7 @@ The update-pce and --no-prompt flags are ignored for this command.`,
 		}
 
 		// Get the files in that directory
-		files, err := ioutil.ReadDir(directory)
+		files, err := os.ReadDir(directory)
 		if err != nil {
 			utils.LogError(err.Error())
 		}

--- a/cmd/vmsync/utils.go
+++ b/cmd/vmsync/utils.go
@@ -5,7 +5,7 @@ import (
 	"crypto/tls"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -64,7 +64,7 @@ func httpCall(httpAction, apiURL string, body []byte, login bool) (illumioapi.AP
 	defer resp.Body.Close()
 
 	// Process response
-	data, err := ioutil.ReadAll(resp.Body)
+	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return response, err
 	}


### PR DESCRIPTION
## Summary
- `cmd/templatelist/cmd.go`: `ioutil.ReadDir()` → `os.ReadDir()`
- `cmd/vmsync/utils.go`: `ioutil.ReadAll()` → `io.ReadAll()`
- `cmd/dagsync/cmd.go`: `ioutil.ReadAll()` → `io.ReadAll()`

`io/ioutil` has been deprecated since Go 1.16. These are the last three usages in the codebase.

## Test plan
- [x] `go vet` passes for all three packages
- [x] No remaining `ioutil` imports

🤖 Generated with [Claude Code](https://claude.com/claude-code)