### PR TITLE
fix: add retry logic for EOF errors in unused-umwl

### DIFF
--- a/cmd/unusedumwl/unusedUmwl.go
+++ b/cmd/unusedumwl/unusedUmwl.go
@@ -59,12 +59,25 @@ func unusedUmwl() {
 	csvData := [][]string{{"hostname", "name", "href", "role", "app", "env", "loc", "interfaces", "traffic_count"}}
 
 	// Iterate over UMWLs
-	for _, umwl := range umwls {
+	for i, umwl := range umwls {
 		tq.SourcesInclude = [][]string{{umwl.Href}}
 		tq.DestinationsInclude = [][]string{{umwl.Href}}
-		traffic, a, err := pce.GetTrafficAnalysis(tq)
-		utils.LogAPIResp("GetTrafficAnalysis", a)
-		if err != nil {
+
+		// Retry logic to handle EOF errors from stale connections on long-running operations
+		var traffic []illumioapi.TrafficAnalysis
+		var a illumioapi.APIResponse
+		maxRetries := 3
+		for attempt := 0; attempt < maxRetries; attempt++ {
+			traffic, a, err = pce.GetTrafficAnalysis(tq)
+			utils.LogAPIResp("GetTrafficAnalysis", a)
+			if err == nil {
+				break
+			}
+			if strings.Contains(err.Error(), "EOF") && attempt < maxRetries-1 {
+				utils.LogWarning(fmt.Sprintf("EOF error on umwl %d/%d (%s), retrying (attempt %d/%d)...", i+1, len(umwls), umwl.Href, attempt+2, maxRetries), true)
+				time.Sleep(5 * time.Second)
+				continue
+			}
 			utils.LogError(err.Error())
 		}
 


### PR DESCRIPTION
## Summary
- Adds retry logic (up to 3 attempts with 5-second backoff) for EOF errors in the `unused-umwl` command
- Logs a warning with progress info when retrying, so the user can see the recovery
- Non-EOF errors still fail immediately as before

## Root Cause
The `unused-umwl` command iterates over potentially thousands of UMWLs, making a `GetTrafficAnalysis` API call for each one. After hours of processing (5-10 hours, 2100-2600 UMWLs), the HTTP connection goes stale and the next API call returns EOF. The Go HTTP client reuses pooled connections, but the server may have closed the connection in the meantime.

## Test plan
- [ ] Run `unused-umwl` against a PCE with 2500+ UMWLs and verify it completes without EOF crash
- [ ] Verify that non-EOF errors still cause immediate failure
- [x] `go vet` passes

Fixes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)