### PR TITLE
add --ignore-href flag to all import commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 workloader
+dist/
 *.code-workspace
 *.DS_store
 *.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+workloader
 *.code-workspace
 *.DS_store
 *.log

--- a/cmd/azurenetwork/cmd.go
+++ b/cmd/azurenetwork/cmd.go
@@ -125,7 +125,7 @@ func AzureNetworks(pce *illumioapi.PCE, provision, updatePCE, noPrompt bool) {
 
 		utils.LogInfo("passing output into ipl-import...", true)
 
-		iplimport.ImportIPLists(*pce, outputFileName, updatePCE, noPrompt, false, provision)
+		iplimport.ImportIPLists(*pce, outputFileName, updatePCE, noPrompt, false, provision, false)
 
 	} else {
 		utils.LogInfo("no azure networks found", true)

--- a/cmd/denyruleimport/cmd.go
+++ b/cmd/denyruleimport/cmd.go
@@ -19,7 +19,7 @@ type Input struct {
 	ImportFile                                   string
 	ProvisionComment                             string
 	Headers                                      map[string]int
-	Provision, UpdatePCE, NoPrompt, CreateLabels bool
+	Provision, UpdatePCE, NoPrompt, CreateLabels, IgnoreHref bool
 }
 
 // Decluare a global input and debug variable
@@ -29,6 +29,7 @@ func init() {
 	DenyRuleImportCmd.Flags().BoolVar(&cmdInput.CreateLabels, "create-labels", false, "create labels if they do not exist.")
 	DenyRuleImportCmd.Flags().BoolVar(&cmdInput.Provision, "provision", false, "provision eb creations/changes.")
 	DenyRuleImportCmd.Flags().StringVar(&cmdInput.ProvisionComment, "provision-comment", "", "comment for when provisioning changes.")
+	DenyRuleImportCmd.Flags().BoolVar(&cmdInput.IgnoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
 }
 
 // RuleImportCmd runs the upload command
@@ -146,8 +147,8 @@ func ImportBoundariesFromCSV(input Input) {
 		// Start the row href variable
 		var rowHref string
 
-		// If there is an href provided makae sure it exists
-		if c, ok := input.Headers[denyruleexport.HeaderHref]; ok && row[c] != "" {
+		// If there is an href provided and it's not ignored, make sure it exists
+		if c, ok := input.Headers[denyruleexport.HeaderHref]; ok && row[c] != "" && !input.IgnoreHref {
 			rowHref = row[c]
 			if _, ebCheck := input.PCE.EnforcementBoundaries[row[c]]; !ebCheck {
 				utils.LogWarning(fmt.Sprintf("csv line %d - %s href does not exist. skipping.", rowIndex+1, row[input.Headers[denyruleexport.HeaderHref]]), true)

--- a/cmd/iplimport/iplimport.go
+++ b/cmd/iplimport/iplimport.go
@@ -16,11 +16,12 @@ import (
 // Declare local global variables
 var pce ia.PCE
 var err error
-var provision, debug, updatePCE, noPrompt bool
+var provision, debug, updatePCE, noPrompt, ignoreHref bool
 var csvFile string
 
 func init() {
 	IplImportCmd.Flags().BoolVarP(&provision, "provision", "p", false, "Provision IP Lists after creating and/or updating.")
+	IplImportCmd.Flags().BoolVar(&ignoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
 }
 
 // IplImportCmd runs the iplist import command
@@ -78,12 +79,12 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		updatePCE = viper.GetBool("update_pce")
 		noPrompt = viper.GetBool("no_prompt")
 
-		ImportIPLists(pce, csvFile, updatePCE, noPrompt, debug, provision)
+		ImportIPLists(pce, csvFile, updatePCE, noPrompt, debug, provision, ignoreHref)
 	},
 }
 
 // ImportIPLists imports IP Lists to a target PCE from a CSV file
-func ImportIPLists(pce ia.PCE, csvFile string, updatePCE, noPrompt, debug, provision bool) {
+func ImportIPLists(pce ia.PCE, csvFile string, updatePCE, noPrompt, debug, provision, ignoreHref bool) {
 
 	// Parse the CSV
 	csvData, err := utils.ParseCSV(csvFile)
@@ -205,7 +206,7 @@ csvEntries:
 		if val, ok := headers[HeaderExternalDataSet]; ok && line[*val] != "" {
 			ipl.ExternalDataSet = ia.Ptr(line[*val])
 		}
-		if val, ok := headers[HeaderHref]; ok {
+		if val, ok := headers[HeaderHref]; ok && !ignoreHref {
 			ipl.Href = line[*val]
 		}
 		// Add our IPlist to our CSV Map

--- a/cmd/labelgroupimport/labelgroupimport.go
+++ b/cmd/labelgroupimport/labelgroupimport.go
@@ -15,7 +15,7 @@ import (
 
 // Global variables
 var csvFile string
-var provision, updatePCE, noPrompt bool
+var provision, updatePCE, noPrompt, ignoreHref bool
 var pce illumioapi.PCE
 var err error
 
@@ -27,6 +27,7 @@ type entry struct {
 
 func init() {
 	LabelGroupImportCmd.Flags().BoolVarP(&provision, "provision", "p", false, "Provision changes.")
+	LabelGroupImportCmd.Flags().BoolVar(&ignoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
 	LabelGroupImportCmd.Flags().SortFlags = false
 }
 
@@ -113,8 +114,8 @@ CSVEntries:
 			continue
 		}
 
-		// If the href header is not present or the value is blank, it's created
-		if headers[labelgroupexport.HeaderHref] == nil || line[*headers[labelgroupexport.HeaderHref]] == "" {
+		// If the href header is not present, blank, or ignored, it's created
+		if ignoreHref || headers[labelgroupexport.HeaderHref] == nil || line[*headers[labelgroupexport.HeaderHref]] == "" {
 			newLG := illumioapi.LabelGroup{}
 
 			// Name

--- a/cmd/labelimport/cmd.go
+++ b/cmd/labelimport/cmd.go
@@ -30,10 +30,12 @@ const (
 // Declare local global variables
 var pce illumioapi.PCE
 var err error
-var updatePCE, noPrompt bool
+var updatePCE, noPrompt, ignoreHref bool
 var csvFile string
 
-func init() {}
+func init() {
+	LabelImportCmd.Flags().BoolVar(&ignoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
+}
 
 // IplImportCmd runs the iplist import command
 var LabelImportCmd = &cobra.Command{
@@ -71,7 +73,7 @@ Recommended to run without --update-pce first to log of what will change. If --u
 		updatePCE = viper.GetBool("update_pce")
 		noPrompt = viper.GetBool("no_prompt")
 
-		ImportLabels(pce, csvFile, updatePCE, noPrompt)
+		ImportLabels(pce, csvFile, updatePCE, noPrompt, ignoreHref)
 	},
 }
 
@@ -81,7 +83,7 @@ type csvLabel struct {
 }
 
 // ImportLabels imports IP Lists to a target PCE from a CSV file
-func ImportLabels(pce illumioapi.PCE, inputFile string, updatePCE, noPrompt bool) {
+func ImportLabels(pce illumioapi.PCE, inputFile string, updatePCE, noPrompt, ignoreHref bool) {
 
 	// Open CSV File
 	file, err := os.Open(inputFile)
@@ -140,8 +142,8 @@ func ImportLabels(pce illumioapi.PCE, inputFile string, updatePCE, noPrompt bool
 			continue
 		}
 
-		// No href provided means check if the label exists and create it if not
-		if headers[HeaderHref] == nil || line[*headers[HeaderHref]] == "" {
+		// No href provided (or ignored) means check if the label exists and create it if not
+		if ignoreHref || headers[HeaderHref] == nil || line[*headers[HeaderHref]] == "" {
 			// Check if the label already exists in the PCE
 			if val, ok := pce.Labels[line[*headers[HeaderKey]]+line[*headers[HeaderValue]]]; ok {
 				utils.LogInfo(fmt.Sprintf("csv line %d - %s (%s) already exists - %s. to edit provide the href in the csv input.", i, val.Value, val.Key, val.Href), false)

--- a/cmd/ruleimport/ruleimport.go
+++ b/cmd/ruleimport/ruleimport.go
@@ -25,7 +25,7 @@ type Input struct {
 	ProvisionComment                                                                           string
 	Headers                                                                                    map[string]int
 	DeleteFile                                                                                 string
-	Provision, UpdatePCE, NoPrompt, CreateLabels, NoTrimming, MatchOnExtDataRef, Authoritative bool
+	Provision, UpdatePCE, NoPrompt, CreateLabels, NoTrimming, MatchOnExtDataRef, Authoritative, IgnoreHref bool
 }
 
 // Decluare a global input and debug variable
@@ -39,6 +39,7 @@ func init() {
 	RuleImportCmd.Flags().BoolVar(&globalInput.MatchOnExtDataRef, "match-on-ext", false, "match on external data set and reference instead of href for updating existing rules.")
 	RuleImportCmd.Flags().BoolVar(&globalInput.Authoritative, "authoritative", false, "create a csv file of all rule hrefs not on the input file to be passed into the delete command.")
 	RuleImportCmd.Flags().StringVar(&globalInput.DeleteFile, "authoritative-delete-file", "", "name of the csv file to be passed into delete command.")
+	RuleImportCmd.Flags().BoolVar(&globalInput.IgnoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
 
 }
 
@@ -315,7 +316,7 @@ CSVEntries:
 			}
 
 		} else {
-			if c, ok := input.Headers[ruleexport.HeaderRuleHref]; ok && l[c] != "" {
+			if c, ok := input.Headers[ruleexport.HeaderRuleHref]; ok && l[c] != "" && !input.IgnoreHref {
 				rowRuleMatchStr = l[c]
 				if _, rCheck := ruleLookup[l[input.Headers[ruleexport.HeaderRuleHref]]]; !rCheck {
 					utils.LogWarning(fmt.Sprintf("csv line %d - %s rule_href does not exist. Skipping.", i+1, l[input.Headers[ruleexport.HeaderRuleHref]]), true)

--- a/cmd/rulesetimport/import.go
+++ b/cmd/rulesetimport/import.go
@@ -14,9 +14,9 @@ import (
 )
 
 type Input struct {
-	PCE                                        illumioapi.PCE
-	UpdatePCE, NoPrompt, Provision, NoTrimming bool
-	ImportFile, ProvisionComment               string
+	PCE                                                    illumioapi.PCE
+	UpdatePCE, NoPrompt, Provision, NoTrimming, IgnoreHref bool
+	ImportFile, ProvisionComment                           string
 }
 
 var input Input
@@ -25,6 +25,7 @@ func init() {
 	RuleSetImportCmd.Flags().BoolVar(&input.Provision, "provision", false, "Provision changes.")
 	RuleSetImportCmd.Flags().StringVar(&input.ProvisionComment, "provision-comments", "", "Provision comment.")
 	RuleSetImportCmd.Flags().BoolVar(&input.NoTrimming, "no-trimming", false, "Disable default CSV parsing with trimming of whitespaces for label names (leading and ending whitespaces)")
+	RuleSetImportCmd.Flags().BoolVar(&input.IgnoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
 }
 
 // RuleSetImportCmd runs the import command
@@ -122,8 +123,8 @@ csvEntries:
 			continue
 		}
 
-		// If the ruleset href column is provided and there is a value, make sure it's valid.
-		if rsHrefCol, ok := hm["href"]; ok && l[hm["href"]] != "" {
+		// If the ruleset href column is provided, has a value, and is not ignored, make sure it's valid.
+		if rsHrefCol, ok := hm["href"]; ok && l[hm["href"]] != "" && !input.IgnoreHref {
 			var rs illumioapi.RuleSet
 			if rs, ok = input.PCE.RuleSets[l[rsHrefCol]]; !ok {
 				utils.LogError(fmt.Sprintf("csv line %d - provided ruleset href does not exist", i+1))

--- a/cmd/svcimport/cmd.go
+++ b/cmd/svcimport/cmd.go
@@ -19,6 +19,7 @@ func init() {
 	SvcImportCmd.Flags().BoolVarP(&input.Provision, "provision", "p", false, "Provision IP Lists after creating and/or updating.")
 	SvcImportCmd.Flags().BoolVar(&input.UpdateOnName, "update-on-name", false, "Update based on a match name vs. requiring href.")
 	SvcImportCmd.Flags().BoolVarP(&input.Meta, "meta", "m", false, "Used for updating descriptions, names, risk information. Leverages the output from svc-export --compressed")
+	SvcImportCmd.Flags().BoolVar(&input.IgnoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
 }
 
 // SvcImportCmd runs the service import command

--- a/cmd/svcimport/import.go
+++ b/cmd/svcimport/import.go
@@ -20,6 +20,7 @@ type Input struct {
 	Provision    bool
 	UpdateOnName bool
 	Meta         bool
+	IgnoreHref   bool
 	Headers      map[string]int
 }
 
@@ -80,9 +81,7 @@ func ImportServices(input Input) {
 
 			// Get the href
 			var href, name string
-			if hrefCol, ok := input.Headers[svcexport.HeaderHref]; !ok {
-				// utils.LogError("href header required with meta flag")
-			} else {
+			if hrefCol, ok := input.Headers[svcexport.HeaderHref]; ok && !input.IgnoreHref {
 				href = data[hrefCol]
 				if href == "" {
 					utils.LogErrorf("csv line %d - no header provided.", csvLine)
@@ -269,7 +268,7 @@ func ImportServices(input Input) {
 					}
 
 					// Add the href
-					if col, ok := input.Headers[svcexport.HeaderHref]; ok {
+					if col, ok := input.Headers[svcexport.HeaderHref]; ok && !input.IgnoreHref {
 						svc.Href = data[col]
 					} else if input.UpdateOnName {
 						svc.Href = input.PCE.Services[data[nameCol]].Href

--- a/cmd/templateimport/templateimport.go
+++ b/cmd/templateimport/templateimport.go
@@ -84,7 +84,7 @@ func importTemplate() {
 	fmt.Println("\r\n------------------------------------------ LABELS -------------------------------------------")
 	labelFile := fmt.Sprintf("%s%s.labels.csv", directory, template)
 	if _, err := os.Stat(labelFile); err == nil {
-		labelimport.ImportLabels(pce2, labelFile, updatePCE, noPrompt)
+		labelimport.ImportLabels(pce2, labelFile, updatePCE, noPrompt, false)
 	} else {
 		utils.LogInfo(fmt.Sprintf("%s template does not include services. skipping", template), true)
 	}
@@ -106,7 +106,7 @@ func importTemplate() {
 	fmt.Println("\r\n------------------------------------------ IP Lists -------------------------------------------")
 	iplFile := fmt.Sprintf("%s%s.iplists.csv", directory, template)
 	if _, err := os.Stat(iplFile); err == nil {
-		iplimport.ImportIPLists(pce2, iplFile, updatePCE, noPrompt, false, provision)
+		iplimport.ImportIPLists(pce2, iplFile, updatePCE, noPrompt, false, provision, false)
 	} else {
 		utils.LogInfo(fmt.Sprintf("%s template does not include ip lists. skipping", template), true)
 	}

--- a/cmd/wkldimport/cmd.go
+++ b/cmd/wkldimport/cmd.go
@@ -24,7 +24,7 @@ type Input struct {
 	Umwl, KeepAllPCEInterfaces, FqdnToShort, AllowEnforcementChanges, UpdateWorkloads, DoNotLogEachCSVRow, UpdatePCE, NoPrompt bool
 	ManagedOnly                                                                                                                bool
 	UnmanagedOnly                                                                                                              bool
-	IgnoreCase                                                                                                                 bool
+	IgnoreCase, IgnoreHref                                                                                                     bool
 	MaxUpdate, MaxCreate                                                                                                       int
 }
 
@@ -47,6 +47,7 @@ func init() {
 	WkldImportCmd.Flags().StringVar(&input.RemoveValue, "remove-value", "", "value in CSV used to remove existing labels. Blank values in the CSV will not change existing. for example, to delete a label an option would be --remove-value DELETE and use DELETE in CSV to indicate where to clear existing labels on a workload.")
 	WkldImportCmd.Flags().StringVar(&input.MatchString, "match", "", "match options. blank means to follow workloader default logic. Available options are href, hostname, name, and external_data. The default logic uses href if present, then hostname if present, then name if present. The external_data option uses the unique combinatio of external_data_set and external_data_reference.")
 	WkldImportCmd.Flags().BoolVar(&input.IgnoreCase, "ignore-case", false, "ignore case on the match string.")
+	WkldImportCmd.Flags().BoolVar(&input.IgnoreHref, "ignore-href", false, "ignore the href column in the CSV. useful when importing a CSV exported from a different PCE.")
 	WkldImportCmd.Flags().BoolVar(&input.AllowEnforcementChanges, "allow-enforcement-changes", false, "allow wkld-import to update the enforcement state and visibility levels.")
 	WkldImportCmd.Flags().BoolVar(&input.UnmanagedOnly, "unmanaged-only", false, "only label unmanaged workloads in the PCE.")
 	WkldImportCmd.Flags().BoolVar(&input.ManagedOnly, "managed-only", false, "only label managed workloads in the PCE.")

--- a/cmd/wkldimport/headers.go
+++ b/cmd/wkldimport/headers.go
@@ -42,8 +42,8 @@ func (i *Input) ProcessHeaders(headers []string) {
 		return
 	}
 
-	// If href is provided and UMWL is not set, use href
-	if val, ok := i.Headers[wkldexport.HeaderHref]; ok && !i.Umwl {
+	// If href is provided, UMWL is not set, and IgnoreHref is not set, use href
+	if val, ok := i.Headers[wkldexport.HeaderHref]; ok && !i.Umwl && !i.IgnoreHref {
 		i.MatchString = wkldexport.HeaderHref
 		utils.LogInfo(fmt.Sprintf("match column set to %d because href header is present and unmanaged workload flag is not set.", val), false)
 		return


### PR DESCRIPTION
Useful for importing customer exports into a new PCE. Should be used in conjunction with a continue on error flag.