### PR TITLE
unused-umwl: retry on transient PCE errors with exponential backoff

### DIFF
--- a/cmd/unusedumwl/unusedUmwl.go
+++ b/cmd/unusedumwl/unusedUmwl.go
@@ -63,19 +63,21 @@ func unusedUmwl() {
 		tq.SourcesInclude = [][]string{{umwl.Href}}
 		tq.DestinationsInclude = [][]string{{umwl.Href}}
 
-		// Retry logic to handle EOF errors from stale connections on long-running operations
+		// Retry logic with exponential backoff for transient errors (EOF, 401, 502)
 		var traffic []illumioapi.TrafficAnalysis
 		var a illumioapi.APIResponse
-		maxRetries := 3
+		maxRetries := 5
 		for attempt := 0; attempt < maxRetries; attempt++ {
 			traffic, a, err = pce.GetTrafficAnalysis(tq)
 			utils.LogAPIResp("GetTrafficAnalysis", a)
 			if err == nil {
 				break
 			}
-			if strings.Contains(err.Error(), "EOF") && attempt < maxRetries-1 {
-				utils.LogWarning(fmt.Sprintf("EOF error on umwl %d/%d (%s), retrying (attempt %d/%d)...", i+1, len(umwls), umwl.Href, attempt+2, maxRetries), true)
-				time.Sleep(5 * time.Second)
+			retryable := strings.Contains(err.Error(), "EOF") || a.StatusCode == 401 || a.StatusCode == 502 || a.StatusCode == 503
+			if retryable && attempt < maxRetries-1 {
+				backoff := time.Duration(5*(1<<attempt)) * time.Second
+				utils.LogWarning(fmt.Sprintf("transient error (status %d) on umwl %d/%d (%s), retrying in %s (attempt %d/%d)...", a.StatusCode, i+1, len(umwls), umwl.Href, backoff, attempt+2, maxRetries), true)
+				time.Sleep(backoff)
 				continue
 			}
 			utils.LogError(err.Error())


### PR DESCRIPTION
The unused-umwl command fails during long-running operations when the PCE returns transient HTTP errors (401, 502, 503) on the GET /traffic_flows/async_queries polling endpoint. This was observed across multiple customer runs on SaaS clusters.

Extended the existing EOF-only retry logic to also cover 401, 502, and 503 errors with exponential backoff:
  - Retries: 5 attempts (was 3)
  - Backoff: 5s, 10s, 20s, 40s (was fixed 5s)
  - Retryable errors: EOF, 401, 502, 503 (was EOF only)